### PR TITLE
NEPT-2748: Fix password fields

### DIFF
--- a/includes/nexteuropa_poetry.admin.inc
+++ b/includes/nexteuropa_poetry.admin.inc
@@ -29,7 +29,7 @@ function nexteuropa_poetry_client_settings_form() {
   );
   $form['service']['nexteuropa_poetry_service_password'] = array(
     '#title' => t('Password'),
-    '#type' => 'textfield',
+    '#type' => 'password',
     '#required' => TRUE,
     '#default_value' => variable_get('nexteuropa_poetry_service_password', ''),
     '#description' => t('The Poetry client password, as provided by the Poetry remote service.'),
@@ -55,7 +55,7 @@ function nexteuropa_poetry_client_settings_form() {
   );
   $form['notification']['nexteuropa_poetry_notification_password'] = array(
     '#title' => t('Password'),
-    '#type' => 'textfield',
+    '#type' => 'password',
     '#required' => TRUE,
     '#default_value' => variable_get('nexteuropa_poetry_notification_password', ''),
     '#description' => t('Drupal notification callback password, Poetry remote service will use it to authenticate against it.'),


### PR DESCRIPTION
## NEPT-2748

### Description

Regular text fields were used rather than password fields, leaving entered passwords unobscured.

### Change log

- Changed fieldtype to 'password' in nexteuropa_poetry.admin.inc 